### PR TITLE
Code Review

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,12 @@
           ]
         }
       ],
-      "react/prop-types": "off"
+      "react/prop-types": "off",
+      "react/require-default-props": "off",
+      "react/jsx-props-no-spreading": "off",
+      "jsx-a11y/label-has-associated-control": "off",
+      "import/prefer-default-export": "off",
+      "react/function-component-definition": "off"
     }
   },
   "stylelint": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,28 @@
 import React from "react";
 import { Container } from "react-bootstrap";
+import {
+  type IRegistrationFormField,
+  RegistrationForm,
+} from "./features/registration-form";
+import {
+  logPassFields,
+  addressFields,
+  phoneNumberFields,
+} from "./mock/registrationFormData";
 import "./App.scss";
-import RegistrationForm from "./features/registration-form/RegistrationForm";
+
+const mockedFields: IRegistrationFormField[][] = [
+  logPassFields,
+  addressFields,
+  phoneNumberFields,
+];
 
 function App() {
   return (
     <main>
       <Container>
         <h1>Registration</h1>
-        <RegistrationForm />
+        <RegistrationForm fields={mockedFields} />
       </Container>
     </main>
   );

--- a/src/features/registration-form/RegistrationForm.tsx
+++ b/src/features/registration-form/RegistrationForm.tsx
@@ -1,94 +1,90 @@
 import React, { useState } from "react";
 import { Form, FormSpy } from "react-final-form";
+import { LocalStorage } from "../../lib/storage";
 import RegistrationFormItems from "./RegistrationFormItems";
-import {
-  logPassFields,
-  addressFields,
-  phoneNumberFields,
-} from "./registrationFormData";
-import { IRegistrationFormField } from "./types/RegistrationFormFieldInterface";
-import RegistrationFormPhoneVerification from "./RegistrationFormPhoneVerification";
+import type { IRegistrationFormField } from "./types/RegistrationFormFieldInterface";
 
-export default function RegistrationForm() {
-  const [step, setStep] = useState<number>(+localStorage.step || 1);
-  const [code, setCode] = useState<string>("");
+type FormStore = {
+  step: number;
+  values: Record<string, unknown>;
+};
 
-  const fieldsArr: IRegistrationFormField[][] = [
-    logPassFields,
-    addressFields,
-    phoneNumberFields,
-  ];
+const formStore = new LocalStorage<FormStore>("formStore");
+
+const INITIAL_VALUES = formStore.get("values") ?? {};
+
+interface RegistrationFormProps {
+  fields: IRegistrationFormField[][];
+}
+
+export const RegistrationForm = ({ fields = [] }: RegistrationFormProps) => {
+  const [step, setStep] = useState<number>(() => formStore.get("step") ?? 1);
+  const [phoneCode, setPhoneCode] = useState<string>("");
 
   const changeStep = (delta: number) => {
     const nextStep = step + delta;
 
     if (nextStep < 1) {
       setStep(1);
-
-      localStorage.setItem("step", "1");
-
       return;
     }
 
-    if (nextStep > fieldsArr.length) {
-      setStep(fieldsArr.length);
-
-      localStorage.setItem("step", String(fieldsArr.length));
-
+    if (nextStep > fields.length) {
+      setStep(fields.length);
       return;
     }
-
-    localStorage.setItem("step", String(nextStep));
 
     setStep(nextStep);
   };
 
-  const isLastStep = step === fieldsArr.length;
+  const isLastStep = step === fields.length;
 
-  const onSubmit = (values: Record<string, any>) => {
+  const onSubmit = (valuesRaw: Record<string, unknown>) => {
     if (isLastStep) {
-      return alert(`Submitted with values: ${JSON.stringify(values, null, 2)}`);
+      return alert(
+        `Submitted with values: ${JSON.stringify(valuesRaw, null, 2)}`
+      );
     }
 
     return changeStep(1);
   };
 
+  React.useEffect(
+    function handleStepForSaveToStore() {
+      formStore.set("step", step);
+    },
+    [step]
+  );
+
   return (
     <Form
-      initialValues={
-        (localStorage.values && JSON.parse(localStorage.values)) || {}
-      }
+      initialValues={INITIAL_VALUES}
       onSubmit={onSubmit}
       render={({ handleSubmit }) => (
-        <>
+        <form onSubmit={handleSubmit} noValidate>
           <FormSpy
             onChange={(formState) => {
-              localStorage.setItem("values", JSON.stringify(formState.values));
+              formStore.set("values", formState.values);
             }}
           />
-          <form onSubmit={handleSubmit} noValidate>
-            <RegistrationFormItems fields={fieldsArr[step - 1]}>
-              {step === fieldsArr.length && (
-                <RegistrationFormPhoneVerification
-                  code={code}
-                  setCode={setCode}
-                />
-              )}
-            </RegistrationFormItems>
-            <button
-              type="button"
-              className="btn btn-primary me-3"
-              disabled={step === 1}
-              onClick={() => changeStep(-1)}
-            >
-              Prev
-            </button>
-            <button type="submit" className="btn btn-primary me-3">
-              {isLastStep ? "Submit" : "Next"}
-            </button>
-          </form>
-        </>
+          <RegistrationFormItems
+            fields={fields[step - 1]}
+            phoneCode={phoneCode}
+            onPhoneCodeChange={setPhoneCode}
+          />
+          <button
+            type="button"
+            className="btn btn-primary me-3"
+            disabled={step === 1}
+            onClick={() => changeStep(-1)}
+          >
+            Prev
+          </button>
+          <button type="submit" className="btn btn-primary me-3">
+            {isLastStep ? "Submit" : "Next"}
+          </button>
+        </form>
       )}
     />
   );
-}
+};

--- a/src/features/registration-form/RegistrationFormItem.tsx
+++ b/src/features/registration-form/RegistrationFormItem.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
-/* eslint-disable jsx-a11y/label-has-associated-control */
 import React from "react";
 import { Field } from "react-final-form";
 import { IRegistrationFormField } from "./types/RegistrationFormFieldInterface";

--- a/src/features/registration-form/RegistrationFormItems.tsx
+++ b/src/features/registration-form/RegistrationFormItems.tsx
@@ -1,23 +1,34 @@
-/* eslint-disable react/require-default-props */
 import React from "react";
 import { IRegistrationFormField } from "./types/RegistrationFormFieldInterface";
 import RegistrationFormItem from "./RegistrationFormItem";
+import RegistrationFormPhoneVerification from "./RegistrationFormPhoneVerification";
 
 interface IRegistrationFormItemsProps {
   fields: IRegistrationFormField[];
-  children?: React.ReactNode;
+  phoneCode?: string;
+  onPhoneCodeChange?(code: string): void;
 }
 
 export default function RegistrationFormItems({
   fields,
-  children = null,
+  phoneCode,
+  onPhoneCodeChange,
 }: IRegistrationFormItemsProps) {
   return (
     <>
-      {fields.map((item) => (
-        <RegistrationFormItem key={item.field} item={item} />
-      ))}
-      {children}
+      {fields.map((item) =>
+        item.type === "tel" ? (
+          <React.Fragment key={item.field}>
+            <RegistrationFormItem item={item} />
+            <RegistrationFormPhoneVerification
+              code={phoneCode}
+              setCode={onPhoneCodeChange}
+            />
+          </React.Fragment>
+        ) : (
+          <RegistrationFormItem key={item.field} item={item} />
+        )
+      )}
     </>
   );
 }

--- a/src/features/registration-form/RegistrationFormPhoneVerification.tsx
+++ b/src/features/registration-form/RegistrationFormPhoneVerification.tsx
@@ -1,12 +1,10 @@
-/* eslint-disable react/jsx-props-no-spreading */
-/* eslint-disable jsx-a11y/label-has-associated-control */
 import React from "react";
 import { Field } from "react-final-form";
 import { checkCode } from "./registrationFormValidators";
 
 interface IRegistrationFormPhoneVerificationProps {
-  code: string;
-  setCode: React.Dispatch<React.SetStateAction<string>>;
+  code?: string;
+  setCode?(code: string): void;
 }
 
 export default function RegistrationFormPhoneVerification({
@@ -28,7 +26,7 @@ export default function RegistrationFormPhoneVerification({
       <button
         type="button"
         className="btn btn-primary mb-3"
-        onClick={() => setCode(generateCode())}
+        onClick={() => setCode?.(generateCode())}
       >
         Get code
       </button>

--- a/src/features/registration-form/index.ts
+++ b/src/features/registration-form/index.ts
@@ -1,0 +1,3 @@
+export type { IRegistrationFormField } from "./types/RegistrationFormFieldInterface";
+
+export { RegistrationForm } from "./RegistrationForm";

--- a/src/features/registration-form/registrationFormValidators.ts
+++ b/src/features/registration-form/registrationFormValidators.ts
@@ -5,7 +5,7 @@ interface IRegistrationsFormErrors {
 const required = (value: string) =>
   value ? undefined : "This field is required.";
 
-const checkCode = (value: string, code: string) =>
+const checkCode = (value: string, code?: string) =>
   code && value === code ? undefined : "Verification code is incorrect.";
 
 export { type IRegistrationsFormErrors, required, checkCode };

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,0 +1,37 @@
+export class LocalStorage<Store extends Record<string, unknown>> {
+  private store: Store | null = null;
+
+  constructor(private id: string) {
+    const rawData = localStorage.getItem(this.id);
+    if (rawData) {
+      try {
+        this.store = JSON.parse(rawData);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  }
+
+  private saveToStore(): void {
+    if (this.store) {
+      localStorage.setItem(this.id, JSON.stringify(this.store));
+    }
+  }
+
+  set<T extends keyof Store, K extends Store[T]>(key: T, value: K): void {
+    if (this.store) {
+      this.store[key] = value;
+    } else {
+      this.store = Object.create({ [key]: value });
+    }
+    this.saveToStore();
+  }
+
+  get<T extends keyof Store>(key: T): null | Store[T] {
+    if (!this.store) {
+      return null;
+    }
+
+    return this.store[key];
+  }
+}

--- a/src/mock/registrationFormData.ts
+++ b/src/mock/registrationFormData.ts
@@ -1,4 +1,4 @@
-import { IRegistrationFormField } from "./types/RegistrationFormFieldInterface";
+import type { IRegistrationFormField } from "../features/registration-form";
 
 export const logPassFields: IRegistrationFormField[] = [
   {


### PR DESCRIPTION
## Что было сделано?

- Вынес `localStorage` в абстракцию `LocalStorage` – теперь один ключ это одна сущность. Это уменьшает коллизию ключей в `localStorage`.
- Верификация телефона теперь привязана на `field.type === "tel"`, а не на последний шаг.
- Вынес данные на уровень приложения в папку `/mock`

## Что можно улучшить?

- `react-final-form` умеет в хуки, поэтому можно было бы на них переписать вместо render props
- создание `formStore` можно вынести в отдельный файлик на уровне `features/registration-form/` – подумать/изучить как такое организовать (ключевые слова `cache`, `store`)
- верификацию телефона можно попробовать сделать полностью обособленным – сейчас при проверке рендерится два компонента, а можно было бы их объединить (типа это тот же `RegistrationFormItem`, но расширенным функционалом)
    https://github.com/ilovesg/wizard-registration-form/blob/2cc46f34f3f768458d4ad9d150c6ba72ae5ae632/src/features/registration-form/RegistrationFormItems.tsx#L20-L28